### PR TITLE
Implement cappuccino customization modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           <button class="bg-white text-black px-4 py-1 rounded-full">210</button>
         </div>
       </div>
-      <div class="flex items-center justify-between pt-2">
+      <div id="cappuccino-option" class="flex items-center justify-between pt-2 cursor-pointer">
         <span>Капучино</span>
         <div class="flex gap-2 text-[10px]">
           <button class="bg-neutral-800 px-4 py-1 rounded-full">180</button>
@@ -76,5 +76,70 @@
       </div>
     </div>
   </div>
+  <!-- Drink customization modal -->
+  <div id="drink-overlay" class="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-end justify-center z-10 hidden">
+    <div id="drink-menu" class="bg-zinc-900 w-full rounded-t-2xl p-4 transform translate-y-full transition-transform duration-300">
+      <div class="flex justify-between items-start mb-4">
+        <div>
+          <h3 class="font-nyght text-xl italic">Капучино</h3>
+          <p class="text-sm text-zinc-400">Эспрессо с молоком</p>
+        </div>
+        <button id="close-overlay" class="text-2xl leading-none">&times;</button>
+      </div>
+      <div class="mb-4">
+        <div class="flex gap-2 volume-options text-xs">
+          <button class="bg-white text-black px-3 py-1 rounded-full">0.25</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full">0.35</button>
+        </div>
+      </div>
+      <div class="mb-4">
+        <h4 class="mb-2 text-sm">Молоко</h4>
+        <div class="flex gap-2 milk-options text-xs">
+          <button class="bg-white text-black px-3 py-1 rounded-full">Обычное</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full">Кокос</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full">Миндаль</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full">Безлактозное</button>
+        </div>
+      </div>
+      <div class="mb-4">
+        <h4 class="mb-2 text-sm">Сиропы</h4>
+        <div class="flex gap-2 overflow-x-auto syrup-options text-xs pb-2">
+          <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Ваниль</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Карамель</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Шоколад</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Орех</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Клен</button>
+        </div>
+      </div>
+      <div class="mb-4">
+        <h4 class="mb-2 text-sm">Где будете пить</h4>
+        <div class="flex gap-2 place-options text-xs">
+          <button class="bg-white text-black px-3 py-1 rounded-full">Здесь</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full">С собой</button>
+        </div>
+      </div>
+      <div class="mb-4">
+        <h4 class="mb-2 text-sm">Сахар</h4>
+        <div class="flex gap-2 sugar-options text-xs">
+          <button class="bg-neutral-800 px-3 py-1 rounded-full">0</button>
+          <button class="bg-white text-black px-3 py-1 rounded-full">1</button>
+          <button class="bg-neutral-800 px-3 py-1 rounded-full">2</button>
+        </div>
+      </div>
+      <div class="mb-4">
+        <h4 class="mb-2 text-sm">Количество</h4>
+        <div class="flex items-center gap-4">
+          <button id="minus" class="bg-neutral-800 w-8 h-8 rounded-full flex items-center justify-center">-</button>
+          <span id="quantity">1</span>
+          <button id="plus" class="bg-neutral-800 w-8 h-8 rounded-full flex items-center justify-center">+</button>
+        </div>
+      </div>
+      <button id="add-to-order" class="border border-white text-white w-full py-2 rounded-full flex items-center justify-center gap-2">
+        Добавить в заказ
+        <span>→</span>
+      </button>
+    </div>
+  </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,28 @@ function toggleButtonActive(buttonGroupSelector) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  // Открытие и закрытие подменю
+  const drinkRow = document.getElementById('cappuccino-option');
+  const overlay = document.getElementById('drink-overlay');
+  const menu = document.getElementById('drink-menu');
+  const closeBtn = document.getElementById('close-overlay');
+
+  function openMenu() {
+    overlay.classList.remove('hidden');
+    requestAnimationFrame(() => menu.classList.remove('translate-y-full'));
+  }
+
+  function closeMenu() {
+    menu.classList.add('translate-y-full');
+    setTimeout(() => overlay.classList.add('hidden'), 300);
+  }
+
+  drinkRow?.addEventListener('click', openMenu);
+  closeBtn?.addEventListener('click', closeMenu);
+  overlay?.addEventListener('click', e => {
+    if (e.target === overlay) closeMenu();
+  });
+
   // Группы переключателей
   toggleButtonActive('.milk-options');
   toggleButtonActive('.volume-options');


### PR DESCRIPTION
## Summary
- open a slide-up modal to customize Cappuccino
- add overlay markup and button groups
- include JS logic for opening/closing the modal and updating selections

## Testing
- `node -c script.js` *(fails: unknown option)*

------
https://chatgpt.com/codex/tasks/task_e_6845690e432483299a5181d6146c960a