### PR TITLE
Add drink prices and volume selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,39 +39,54 @@
       <h3 class="text-xl italic font-nyght">Классика кофе</h3>
     </div>
     <div class="space-y-4 divide-y divide-zinc-800">
-      <div class="flex items-center justify-between pt-2">
+      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="espresso">
         <span>Эспрессо</span>
-        <div class="flex gap-2 text-[10px]">
-          <button class="bg-neutral-800 px-4 py-1 rounded-full">180</button>
-          <button class="bg-white text-black px-4 py-1 rounded-full">210</button>
+        <div class="price-options flex gap-2 text-[10px]">
+          <button data-volume="0.25" class="bg-neutral-800 px-4 py-1 rounded-full">150</button>
         </div>
       </div>
-      <div class="flex items-center justify-between pt-2">
+      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="americano">
         <span>Американо</span>
-        <div class="flex gap-2 text-[10px]">
-          <button class="bg-neutral-800 px-4 py-1 rounded-full">180</button>
-          <button class="bg-white text-black px-4 py-1 rounded-full">210</button>
+        <div class="price-options flex gap-2 text-[10px]">
+          <button data-volume="0.25" class="bg-neutral-800 px-4 py-1 rounded-full">150</button>
+          <button data-volume="0.35" class="bg-neutral-800 px-4 py-1 rounded-full">160</button>
         </div>
       </div>
-      <div id="cappuccino-option" class="flex items-center justify-between pt-2 cursor-pointer">
+      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="filter">
+        <span>Фильтр</span>
+        <div class="price-options flex gap-2 text-[10px]">
+          <button data-volume="0.35" class="bg-neutral-800 px-4 py-1 rounded-full">170</button>
+        </div>
+      </div>
+      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="flat">
+        <span>Флэт уайт</span>
+        <div class="price-options flex gap-2 text-[10px]">
+          <button data-volume="0.25" class="bg-neutral-800 px-4 py-1 rounded-full">180</button>
+        </div>
+      </div>
+      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="cappuccino">
         <span>Капучино</span>
-        <div class="flex gap-2 text-[10px]">
-          <button class="bg-neutral-800 px-4 py-1 rounded-full">180</button>
-          <button class="bg-white text-black px-4 py-1 rounded-full">210</button>
+        <div class="price-options flex gap-2 text-[10px]">
+          <button data-volume="0.25" class="bg-neutral-800 px-4 py-1 rounded-full">180</button>
+          <button data-volume="0.35" class="bg-neutral-800 px-4 py-1 rounded-full">210</button>
         </div>
       </div>
-      <div class="flex items-center justify-between pt-2">
-        <span>Флэт Уайт</span>
-        <div class="flex gap-2 text-[10px]">
-          <button class="bg-neutral-800 px-4 py-1 rounded-full">180</button>
-          <button class="bg-white text-black px-4 py-1 rounded-full">210</button>
+      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="latte">
+        <span>Латте</span>
+        <div class="price-options flex gap-2 text-[10px]">
+          <button data-volume="0.35" class="bg-neutral-800 px-4 py-1 rounded-full">210</button>
         </div>
       </div>
-      <div class="flex items-center justify-between pt-2">
+      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="raf">
         <span>Раф</span>
-        <div class="flex gap-2 text-[10px]">
-          <button class="bg-neutral-800 px-4 py-1 rounded-full">180</button>
-          <button class="bg-white text-black px-4 py-1 rounded-full">210</button>
+        <div class="price-options flex gap-2 text-[10px]">
+          <button data-volume="0.35" class="bg-neutral-800 px-4 py-1 rounded-full">230</button>
+        </div>
+      </div>
+      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="mocha">
+        <span>Мокко</span>
+        <div class="price-options flex gap-2 text-[10px]">
+          <button data-volume="0.35" class="bg-neutral-800 px-4 py-1 rounded-full">230</button>
         </div>
       </div>
     </div>
@@ -88,8 +103,8 @@
       </div>
       <div class="mb-4">
         <div class="flex gap-2 volume-options text-xs">
-          <button class="bg-white text-black px-3 py-1 rounded-full">0.25</button>
-          <button class="bg-neutral-800 px-3 py-1 rounded-full">0.35</button>
+          <button data-volume="0.25" class="bg-white text-black px-3 py-1 rounded-full">0.25</button>
+          <button data-volume="0.35" class="bg-neutral-800 px-3 py-1 rounded-full">0.35</button>
         </div>
       </div>
       <div class="mb-4">

--- a/script.js
+++ b/script.js
@@ -14,12 +14,27 @@ function toggleButtonActive(buttonGroupSelector) {
 
 document.addEventListener('DOMContentLoaded', () => {
   // Открытие и закрытие подменю
-  const drinkRow = document.getElementById('cappuccino-option');
+  const drinkRows = document.querySelectorAll('.drink-row');
   const overlay = document.getElementById('drink-overlay');
   const menu = document.getElementById('drink-menu');
   const closeBtn = document.getElementById('close-overlay');
 
-  function openMenu() {
+  const selectedVolumes = {};
+  let currentDrink = '';
+
+  function openMenu(row) {
+    currentDrink = row.dataset.drink;
+    const name = row.querySelector('span').textContent;
+    menu.querySelector('h3').textContent = name;
+
+    const volume = selectedVolumes[currentDrink];
+    document.querySelectorAll('.volume-options button').forEach(btn => {
+      btn.classList.remove('bg-white', 'text-black');
+      if (volume ? btn.dataset.volume === volume : btn === document.querySelector('.volume-options button')) {
+        btn.classList.add('bg-white', 'text-black');
+      }
+    });
+
     overlay.classList.remove('hidden');
     requestAnimationFrame(() => menu.classList.remove('translate-y-full'));
   }
@@ -29,10 +44,22 @@ document.addEventListener('DOMContentLoaded', () => {
     setTimeout(() => overlay.classList.add('hidden'), 300);
   }
 
-  drinkRow?.addEventListener('click', openMenu);
+  drinkRows.forEach(row => row.addEventListener('click', () => openMenu(row)));
   closeBtn?.addEventListener('click', closeMenu);
   overlay?.addEventListener('click', e => {
     if (e.target === overlay) closeMenu();
+  });
+
+  // Запоминание выбранного объёма в списке напитков
+  document.querySelectorAll('.price-options').forEach(group => {
+    group.addEventListener('click', e => {
+      if (e.target.tagName === 'BUTTON') {
+        const row = group.closest('[data-drink]');
+        if (row) {
+          selectedVolumes[row.dataset.drink] = e.target.dataset.volume;
+        }
+      }
+    });
   });
 
   // Группы переключателей
@@ -41,6 +68,14 @@ document.addEventListener('DOMContentLoaded', () => {
   toggleButtonActive('.syrup-options');
   toggleButtonActive('.place-options');
   toggleButtonActive('.sugar-options');
+  toggleButtonActive('.price-options');
+
+  // Сохранение объёма из подменю
+  document.querySelector('.volume-options').addEventListener('click', e => {
+    if (e.target.tagName === 'BUTTON' && currentDrink) {
+      selectedVolumes[currentDrink] = e.target.dataset.volume;
+    }
+  });
 
   // Счётчик количества
   const minus = document.querySelector('#minus');
@@ -67,8 +102,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const place = document.querySelector('.place-options .bg-white')?.textContent.trim();
     const sugar = document.querySelector('.sugar-options .bg-white')?.textContent.trim();
 
+    if (currentDrink) {
+      selectedVolumes[currentDrink] = volume;
+    }
+
     const order = {
-      напиток: 'Капучино',
+      напиток: menu.querySelector('h3').textContent,
       молоко: milk,
       объём: volume,
       сироп: syrup,


### PR DESCRIPTION
## Summary
- list all drinks with volume-based price buttons
- store selected volume per drink and preselect in submenu
- open submenu from any drink row

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684572bb80bc832993f5b47f87cb1aaa