### PR TITLE
Improve coffee menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,57 +36,57 @@
     <!-- Coffee Classics -->
     <div class="flex items-center justify-between mt-8 mb-2">
       <div class="flex items-center gap-2">
-        <div class="w-1 h-6 bg-yellow-400 rounded-full"></div>
-        <h3 class="text-2xl font-bold font-nyght">Классика кофе</h3>
+        <div class="w-[1.5px] h-6 bg-yellow-400 rounded-full"></div>
+        <h3 class="text-2xl italic font-nyght">Классика кофе</h3>
       </div>
       <span class="text-xs text-zinc-400">0.25 / 0.35 мл</span>
     </div>
-      <div class="space-y-4 divide-y divide-zinc-800 mb-6">
-        <div class="flex items-center justify-between pt-2">
+      <div class="divide-y divide-zinc-800 mb-6 px-6">
+        <div class="flex items-center justify-between py-3">
           <span>Эспрессо</span>
           <div class="price-options flex gap-2 text-sm">
             <button class="bg-neutral-800 w-12 h-8 rounded-full">150</button>
           </div>
         </div>
-        <div class="flex items-center justify-between pt-2">
+        <div class="flex items-center justify-between py-3">
           <span>Американо</span>
           <div class="price-options flex gap-2 text-sm">
             <button class="bg-neutral-800 w-12 h-8 rounded-full">150</button>
             <button class="bg-neutral-800 w-12 h-8 rounded-full">160</button>
           </div>
         </div>
-        <div class="flex items-center justify-between pt-2">
+        <div class="flex items-center justify-between py-3">
           <span>Фильтр</span>
           <div class="price-options flex gap-2 text-sm">
             <button class="bg-neutral-800 w-12 h-8 rounded-full">170</button>
           </div>
         </div>
-        <div class="flex items-center justify-between pt-2">
+        <div class="flex items-center justify-between py-3">
           <span>Флэт уайт</span>
           <div class="price-options flex gap-2 text-sm">
             <button class="bg-neutral-800 w-12 h-8 rounded-full">180</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="cappuccino">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="cappuccino">
           <span>Капучино</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.25" class="bg-neutral-800 w-12 h-8 rounded-full">180</button>
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">210</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="latte">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="latte">
           <span>Латте</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">210</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="raf">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="raf">
           <span>Раф</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">230</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="mocha">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="mocha">
           <span>Мокко</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">230</button>
@@ -97,43 +97,43 @@
     <!-- Author Coffee -->
     <div class="flex items-center justify-between mt-8 mb-2">
       <div class="flex items-center gap-2">
-        <div class="w-1 h-6 bg-yellow-400 rounded-full"></div>
-        <h3 class="text-2xl font-bold font-nyght">Авторский кофе</h3>
+        <div class="w-[1.5px] h-6 bg-yellow-400 rounded-full"></div>
+        <h3 class="text-2xl italic font-nyght">Авторский кофе</h3>
       </div>
       <span class="text-xs text-zinc-400">0.35</span>
     </div>
-      <div class="space-y-4 divide-y divide-zinc-800 mb-6">
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="raspberry-popcorn-raf">
+      <div class="divide-y divide-zinc-800 mb-6 px-6">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="raspberry-popcorn-raf">
           <span>Раф малиновая глазурь-попкорн</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="cheese-latte">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="cheese-latte">
           <span>Сырный латте</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">240</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="pistachio-latte">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="pistachio-latte">
           <span>Латте фисташковый</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="cherry-panacotta-latte">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="cherry-panacotta-latte">
           <span>Латте вишневая панакота</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="lemon-meringue-latte">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="lemon-meringue-latte">
           <span>Латте лимонный тарт с меренгой</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
           </div>
         </div>
-        <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="gingerbread-latte">
+        <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="gingerbread-latte">
           <span>Латте имбирный пряник</span>
           <div class="price-options flex gap-2 text-sm">
             <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">240</button>
@@ -143,17 +143,17 @@
 
     <!-- Cold Coffee -->
     <div class="flex items-center gap-2 mt-8 mb-2">
-      <div class="w-1 h-6 bg-yellow-400 rounded-full"></div>
-      <h3 class="text-2xl font-bold font-nyght">Холодный кофе</h3>
+      <div class="w-[1.5px] h-6 bg-yellow-400 rounded-full"></div>
+      <h3 class="text-2xl italic font-nyght">Холодный кофе</h3>
     </div>
-    <div class="space-y-4 divide-y divide-zinc-800">
-      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="ice-latte">
+    <div class="divide-y divide-zinc-800 px-6">
+      <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="ice-latte">
         <span>Айс-латте</span>
         <div class="price-options flex gap-2 text-sm">
           <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">220</button>
         </div>
       </div>
-      <div class="drink-row flex items-center justify-between pt-2 cursor-pointer" data-drink="bumblebee">
+      <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="bumblebee">
         <span>Шмель</span>
         <div class="price-options flex gap-2 text-sm">
           <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
@@ -189,8 +189,8 @@
       <div class="mb-4">
         <h4 class="mb-2 text-sm">Сиропы</h4>
         <div class="relative">
-          <button id="syrup-left" class="absolute left-0 top-1/2 -translate-y-1/2 bg-neutral-800 w-8 h-8 rounded-full flex items-center justify-center">&#8249;</button>
-          <div class="flex gap-2 overflow-x-auto syrup-options text-xs pb-2 px-10">
+          <button id="syrup-left" class="absolute left-1 top-1/2 -translate-y-1/2 bg-neutral-800 w-8 h-8 rounded-full text-white flex items-center justify-center">&#8249;</button>
+          <div class="flex gap-2 overflow-x-auto syrup-options text-xs pb-2 px-8">
             <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Карамель</button>
             <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Солёная карамель</button>
             <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Ваниль</button>
@@ -212,7 +212,7 @@
             <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Лемонграсс</button>
             <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Лаванда</button>
           </div>
-          <button id="syrup-right" class="absolute right-0 top-1/2 -translate-y-1/2 bg-neutral-800 w-8 h-8 rounded-full flex items-center justify-center">&#8250;</button>
+          <button id="syrup-right" class="absolute right-1 top-1/2 -translate-y-1/2 bg-neutral-800 w-8 h-8 rounded-full text-white flex items-center justify-center">&#8250;</button>
         </div>
       </div>
       <div class="mb-4">
@@ -225,17 +225,17 @@
       <div class="mb-4">
         <h4 class="mb-2 text-sm">Сахар</h4>
         <div class="flex items-center gap-4">
-          <button id="sugar-minus" class="bg-neutral-800 w-8 h-8 rounded-full flex items-center justify-center">-</button>
+          <button id="sugar-minus" class="bg-neutral-800 w-8 h-8 rounded-full text-white flex items-center justify-center">-</button>
           <span id="sugar-count">1</span>
-          <button id="sugar-plus" class="bg-neutral-800 w-8 h-8 rounded-full flex items-center justify-center">+</button>
+          <button id="sugar-plus" class="bg-neutral-800 w-8 h-8 rounded-full text-white flex items-center justify-center">+</button>
         </div>
       </div>
       <div class="mb-4">
         <h4 class="mb-2 text-sm">Порции</h4>
         <div class="flex items-center gap-4">
-          <button id="portion-minus" class="bg-neutral-800 w-8 h-8 rounded-full flex items-center justify-center">-</button>
+          <button id="portion-minus" class="bg-neutral-800 w-8 h-8 rounded-full text-white flex items-center justify-center">-</button>
           <span id="portion-quantity">1</span>
-          <button id="portion-plus" class="bg-neutral-800 w-8 h-8 rounded-full flex items-center justify-center">+</button>
+          <button id="portion-plus" class="bg-neutral-800 w-8 h-8 rounded-full text-white flex items-center justify-center">+</button>
         </div>
       </div>
       <button id="add-to-order" class="border border-white text-white w-full py-2 rounded-full flex items-center justify-center gap-2">

--- a/script.js
+++ b/script.js
@@ -89,11 +89,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const sugarPlus = document.querySelector('#sugar-plus');
   const sugarQty = document.querySelector('#sugar-count');
 
-  let sugarCount = 1;
+  let sugarCount = 0;
   sugarQty.textContent = sugarCount;
 
   sugarMinus.addEventListener('click', () => {
-    if (sugarCount > 0) sugarQty.textContent = --sugarCount;
+    if (sugarCount > 0) {
+      sugarQty.textContent = --sugarCount;
+    }
   });
 
   sugarPlus.addEventListener('click', () => {
@@ -109,7 +111,9 @@ document.addEventListener('DOMContentLoaded', () => {
   portionQty.textContent = count;
 
   portionMinus.addEventListener('click', () => {
-    if (count > 1) portionQty.textContent = --count;
+    if (count > 0) {
+      portionQty.textContent = --count;
+    }
   });
 
   portionPlus.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- style section headers with italic Nyght Serif
- shrink separator bar width and add padding
- even out spacing for drink rows
- adjust syrup scroller arrows and counter buttons
- fix sugar and portion counters

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68457e8ae88883298e731decb21100a1