### PR TITLE
Fix button toggle and syrup scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,51 +45,51 @@
         <div class="flex items-center justify-between py-3">
           <span>Эспрессо</span>
           <div class="price-options flex gap-2 text-sm">
-            <button class="bg-neutral-800 w-12 h-8 rounded-full">150</button>
+            <button class="bg-neutral-800 text-white w-12 h-8 rounded-full">150</button>
           </div>
         </div>
         <div class="flex items-center justify-between py-3">
           <span>Американо</span>
           <div class="price-options flex gap-2 text-sm">
-            <button class="bg-neutral-800 w-12 h-8 rounded-full">150</button>
-            <button class="bg-neutral-800 w-12 h-8 rounded-full">160</button>
+            <button class="bg-neutral-800 text-white w-12 h-8 rounded-full">150</button>
+            <button class="bg-neutral-800 text-white w-12 h-8 rounded-full">160</button>
           </div>
         </div>
         <div class="flex items-center justify-between py-3">
           <span>Фильтр</span>
           <div class="price-options flex gap-2 text-sm">
-            <button class="bg-neutral-800 w-12 h-8 rounded-full">170</button>
+            <button class="bg-neutral-800 text-white w-12 h-8 rounded-full">170</button>
           </div>
         </div>
         <div class="flex items-center justify-between py-3">
           <span>Флэт уайт</span>
           <div class="price-options flex gap-2 text-sm">
-            <button class="bg-neutral-800 w-12 h-8 rounded-full">180</button>
+            <button class="bg-neutral-800 text-white w-12 h-8 rounded-full">180</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="cappuccino">
           <span>Капучино</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.25" class="bg-neutral-800 w-12 h-8 rounded-full">180</button>
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">210</button>
+            <button data-volume="0.25" class="bg-neutral-800 text-white w-12 h-8 rounded-full">180</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">210</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="latte">
           <span>Латте</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">210</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">210</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="raf">
           <span>Раф</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">230</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">230</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="mocha">
           <span>Мокко</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">230</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">230</button>
           </div>
         </div>
       </div>
@@ -106,37 +106,37 @@
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="raspberry-popcorn-raf">
           <span>Раф малиновая глазурь-попкорн</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">250</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="cheese-latte">
           <span>Сырный латте</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">240</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">240</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="pistachio-latte">
           <span>Латте фисташковый</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">250</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="cherry-panacotta-latte">
           <span>Латте вишневая панакота</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">250</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="lemon-meringue-latte">
           <span>Латте лимонный тарт с меренгой</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">250</button>
           </div>
         </div>
         <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="gingerbread-latte">
           <span>Латте имбирный пряник</span>
           <div class="price-options flex gap-2 text-sm">
-            <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">240</button>
+            <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">240</button>
           </div>
         </div>
       </div>
@@ -150,13 +150,13 @@
       <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="ice-latte">
         <span>Айс-латте</span>
         <div class="price-options flex gap-2 text-sm">
-          <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">220</button>
+          <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">220</button>
         </div>
       </div>
       <div class="drink-row flex items-center justify-between py-3 cursor-pointer" data-drink="bumblebee">
         <span>Шмель</span>
         <div class="price-options flex gap-2 text-sm">
-          <button data-volume="0.35" class="bg-neutral-800 w-12 h-8 rounded-full">250</button>
+          <button data-volume="0.35" class="bg-neutral-800 text-white w-12 h-8 rounded-full">250</button>
         </div>
       </div>
     </div>
@@ -174,43 +174,43 @@
       <div class="mb-4">
         <div class="flex gap-2 volume-options text-xs">
           <button data-volume="0.25" class="bg-white text-black px-3 py-1 rounded-full">0.25</button>
-          <button data-volume="0.35" class="bg-neutral-800 px-3 py-1 rounded-full">0.35</button>
+          <button data-volume="0.35" class="bg-neutral-800 text-white px-3 py-1 rounded-full">0.35</button>
         </div>
       </div>
       <div class="mb-4">
         <h4 class="mb-2 text-sm">Молоко</h4>
         <div class="flex gap-2 milk-options text-xs">
           <button class="bg-white text-black px-3 py-1 rounded-full">Обычное</button>
-          <button class="bg-neutral-800 px-3 py-1 rounded-full">Кокос</button>
-          <button class="bg-neutral-800 px-3 py-1 rounded-full">Миндаль</button>
-          <button class="bg-neutral-800 px-3 py-1 rounded-full">Безлактозное</button>
+          <button class="bg-neutral-800 text-white px-3 py-1 rounded-full">Кокос</button>
+          <button class="bg-neutral-800 text-white px-3 py-1 rounded-full">Миндаль</button>
+          <button class="bg-neutral-800 text-white px-3 py-1 rounded-full">Безлактозное</button>
         </div>
       </div>
       <div class="mb-4">
         <h4 class="mb-2 text-sm">Сиропы</h4>
-        <div class="relative">
+        <div class="relative overflow-hidden">
           <button id="syrup-left" class="absolute left-1 top-1/2 -translate-y-1/2 bg-neutral-800 w-8 h-8 rounded-full text-white flex items-center justify-center">&#8249;</button>
           <div class="flex gap-2 overflow-x-auto syrup-options text-xs pb-2 px-8">
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Карамель</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Солёная карамель</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Ваниль</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Шоколад</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Попкорн</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Миндаль</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Кокос</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Фундук</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Фисташка</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Вишня</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Малина</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Ежевика</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Чёрная смородина</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Бузина</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Яблоко</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Банан</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Маракуйя</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Мята</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Лемонграсс</button>
-            <button class="bg-neutral-800 px-3 py-1 rounded-full flex-shrink-0">Лаванда</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Карамель</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Солёная карамель</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Ваниль</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Шоколад</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Попкорн</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Миндаль</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Кокос</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Фундук</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Фисташка</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Вишня</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Малина</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Ежевика</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Чёрная смородина</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Бузина</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Яблоко</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Банан</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Маракуйя</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Мята</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Лемонграсс</button>
+            <button class="bg-neutral-800 text-white px-3 py-1 rounded-full flex-shrink-0">Лаванда</button>
           </div>
           <button id="syrup-right" class="absolute right-1 top-1/2 -translate-y-1/2 bg-neutral-800 w-8 h-8 rounded-full text-white flex items-center justify-center">&#8250;</button>
         </div>
@@ -219,7 +219,7 @@
         <h4 class="mb-2 text-sm">Где будете пить</h4>
         <div class="flex gap-2 place-options text-xs">
           <button class="bg-white text-black px-3 py-1 rounded-full">Здесь</button>
-          <button class="bg-neutral-800 px-3 py-1 rounded-full">С собой</button>
+          <button class="bg-neutral-800 text-white px-3 py-1 rounded-full">С собой</button>
         </div>
       </div>
       <div class="mb-4">

--- a/script.js
+++ b/script.js
@@ -1,17 +1,27 @@
 // Минимальная интерактивная логика меню
 
-// Подсветка выбранных кнопок
-function toggleButtonActive(buttonGroupSelector, allowToggleOff = false) {
+// Подсветка выбранных кнопок с возможностью отмены
+function toggleButtonActive(buttonGroupSelector) {
   document.querySelectorAll(buttonGroupSelector).forEach(group => {
     group.addEventListener('click', e => {
-      if (e.target.tagName === 'BUTTON') {
-        if (allowToggleOff && e.target.classList.contains('bg-white')) {
-          e.target.classList.remove('bg-white', 'text-black');
-          return;
-        }
-        [...group.children].forEach(btn => btn.classList.remove('bg-white', 'text-black'));
-        e.target.classList.add('bg-white', 'text-black');
+      if (e.target.tagName !== 'BUTTON') return;
+
+      const btn = e.target;
+      const isActive = btn.classList.contains('bg-white');
+
+      if (isActive) {
+        btn.classList.remove('bg-white', 'text-black');
+        btn.classList.add('bg-neutral-800', 'text-white');
+        return;
       }
+
+      [...group.children].forEach(b => {
+        b.classList.remove('bg-white', 'text-black');
+        b.classList.add('bg-neutral-800', 'text-white');
+      });
+
+      btn.classList.remove('bg-neutral-800', 'text-white');
+      btn.classList.add('bg-white', 'text-black');
     });
   });
 }
@@ -34,7 +44,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const volume = selectedVolumes[currentDrink];
     document.querySelectorAll('.volume-options button').forEach(btn => {
       btn.classList.remove('bg-white', 'text-black');
+      btn.classList.add('bg-neutral-800', 'text-white');
       if (volume && btn.dataset.volume === volume) {
+        btn.classList.remove('bg-neutral-800', 'text-white');
         btn.classList.add('bg-white', 'text-black');
       }
     });
@@ -57,17 +69,26 @@ document.addEventListener('DOMContentLoaded', () => {
   // Выбор объёма в списке напитков
   document.querySelectorAll('.price-options').forEach(group => {
     group.addEventListener('click', e => {
-      if (e.target.tagName === 'BUTTON') {
-        const row = group.closest('[data-drink]');
-        if (e.target.classList.contains('bg-white')) {
-          e.target.classList.remove('bg-white', 'text-black');
-          if (row) delete selectedVolumes[row.dataset.drink];
-          return;
-        }
-        [...group.children].forEach(btn => btn.classList.remove('bg-white', 'text-black'));
-        e.target.classList.add('bg-white', 'text-black');
-        if (row) selectedVolumes[row.dataset.drink] = e.target.dataset.volume;
+      if (e.target.tagName !== 'BUTTON') return;
+
+      const row = group.closest('[data-drink]');
+      const btn = e.target;
+
+      if (btn.classList.contains('bg-white')) {
+        btn.classList.remove('bg-white', 'text-black');
+        btn.classList.add('bg-neutral-800', 'text-white');
+        if (row) delete selectedVolumes[row.dataset.drink];
+        return;
       }
+
+      [...group.children].forEach(b => {
+        b.classList.remove('bg-white', 'text-black');
+        b.classList.add('bg-neutral-800', 'text-white');
+      });
+
+      btn.classList.remove('bg-neutral-800', 'text-white');
+      btn.classList.add('bg-white', 'text-black');
+      if (row) selectedVolumes[row.dataset.drink] = btn.dataset.volume;
     });
   });
 


### PR DESCRIPTION
## Summary
- allow deselecting all option buttons
- keep inactive buttons visible with `bg-neutral-800 text-white`
- hide overflowing syrup buttons and scroll with arrows

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684581466f10832989e2447b9a2dcb07